### PR TITLE
Add API and tenant var to endpoints

### DIFF
--- a/src/lib/charm/openstack/trove.py
+++ b/src/lib/charm/openstack/trove.py
@@ -76,11 +76,14 @@ def setup_endpoint(keystone):
     :param keystone: instance of KeystoneRequires() class from i/f
     """
     charm = TroveCharm.singleton
+    public_ep = '{}/v1.0/%(tenant_id)s'.format(charm.public_url)
+    internal_ep = '{}/v1.0/%(tenant_id)s'.format(charm.internal_url)
+    admin_ep = '{}/v1.0/%(tenant_id)s'.format(charm.admin_url)
     keystone.register_endpoints(charm.service_type,
                                 charm.region,
-                                charm.public_url,
-                                charm.internal_url,
-                                charm.admin_url)
+                                public_ep,
+                                internal_ep,
+                                admin_ep)
 
 
 def render_configs(interfaces_list):


### PR DESCRIPTION
When registering the endpoints with Keystone it looks like a
Trove API version and tenant var should be included in the endpoint
string

I'm not creating a pull request for this as the endpoint format is
based on old Icehouse documentation *1 and I'm not sure what Trove
API version the charm supports

*1 http://docs.openstack.org/icehouse/install-guide/install/apt/content/trove-install.html
